### PR TITLE
added new withResourceAndRetry in Pool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-newstyle

--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -296,11 +296,8 @@ withResourceAndRetry pool@Pool{..} act = control $ \runInIO -> mask $ \restore -
     Right r -> putResource local resource *> pure r
     Left (_ :: SomeException) -> do
       LocalPool{..} <- getLocalPool pool
-      destroyResource pool local resource
-      resource' <- liftBase . join . atomically $ do
-        used <- readTVar inUse
-        when (used == maxResources) retry
-        writeTVar inUse $! used + 1
+      destroy resource `E.catch` \(_::SomeException) -> return ()
+      resource' <- liftBase . join . atomically $
         return $ create `onException` atomically (modifyTVar_ inUse (subtract 1))
       return' <- restore (runInIO (act resource')) `onException` destroyResource pool local resource'
       putResource local resource'

--- a/Data/Pool.hs
+++ b/Data/Pool.hs
@@ -277,9 +277,6 @@ withResource pool act = control $ \runInIO -> mask $ \restore -> do
 -- * If the maximum number of resources has been reached, this
 --   function blocks until a resource becomes available.
 --
--- If the action throws an exception of any type, the resource is
--- destroyed, and not returned to the pool.
---
 -- Caution : This function upon any error while taking a bad resource
 -- will destroy the bad resource and will create a new resource in the
 -- same local and keeps it back in the pool.


### PR DESCRIPTION
Problem Description :
In the existing data.pool when a query is acted upon a bad connection which no longer exists , then its closed . But similar connections still exist in the pool which are not removed.

Solution:
Upon detecting a bad connection in a pool a retry is done which creates a new connection to a healthy resource and the query is acted upon it. This connection is put back into the same local from which the bad connection was found. Reactively upon detecting every single bad connection and retrying all bad connections are removed.
